### PR TITLE
Show hidden files fix

### DIFF
--- a/osx/osx-variables
+++ b/osx/osx-variables
@@ -30,5 +30,5 @@ defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false
 defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false
 
 # Show hidden files in finder
-defaults write com.apple.Finder AppleShowAllFiles YES
+defaults write com.apple.finder AppleShowAllFiles YES
 


### PR DESCRIPTION
In Mavericks the "f" needs to be lowercase to work.
In Mountain Lion it was uppercase.
